### PR TITLE
Fix bug preventing using different paths then /opt/venvs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ macros.
 ```
 
 # Use our interpreter for brp-python-bytecompile script
-%global __python /opt/venvs/%{name}/bin/python3
+%global __python %{__pyvenv_root}/bin/python3
 
 
 %prep
@@ -58,10 +58,10 @@ Remember to install all of the executable(s) installed under virtualenv into
 
 The following are the available macros/variables:
 
-#### %__pyvenv_root
+#### %__pyvenv\_root
 
 This points to the directory where the virtualenv has been created. Right now
-the default path is `/opt/venvs/projectname`.
+the default path is `/opt/venvs/<projectname>`.
 
 #### %__pyvenv
 

--- a/examples/ansible.spec
+++ b/examples/ansible.spec
@@ -7,7 +7,7 @@
 
 
 # Use our interpreter for brp-python-bytecompile script
-%global __python /opt/venvs/%{name}/bin/python3
+%global __python %{__pyvenv_root}/bin/python3
 
 
 

--- a/macros.python-virtualenv
+++ b/macros.python-virtualenv
@@ -1,23 +1,45 @@
-%__pyvenv %{buildroot}/opt/venvs/%{name}/bin/python3
-%__pyvenvpip3 %{buildroot}/opt/venvs/%{name}/bin/pip3
-%__pyvenv_root %{buildroot}/opt/venvs/%{name}
+%__pyvenv_root /opt/venvs/%{name}
 
-%pyvenv_create() %{expand:\\\
-  mkdir -p %{buildroot}/opt/venvs/
+%__pyvenv3 %{buildroot}/%{__pyvenv_root}/bin/python3
+%__pyvenvpip3 %{buildroot}/%{__pyvenv_root}/bin/pip3
+
+%__pyvenv2 %{buildroot}/%{__pyvenv_root}/bin/python2
+%__pyvenvpip2 %{buildroot}/%{__pyvenv_root}/bin/pip
+
+%pyvenv_create_3() %{expand:\\\
+  mkdir -p %{buildroot}/%{__pyvenv_root}
   CFLAGS="${CFLAGS:-${RPM_OPT_FLAGS}}" LDFLAGS="${LDFLAGS:-${RPM_LD_FLAGS}}"\\\
-  %{__python3} -m venv %{__pyvenv_root} %{?*}
+  %{__python3} -m venv %{buildroot}/%{__pyvenv_root} %{?*}
   %{__pyvenvpip3} install wheel $PYVENV_WHEEL_ARGS
   sleep 1
 }
 
-%pyvenv_build() %{expand:\\\
-  
+%pyvenv_build_3() %{expand:\\\
   CFLAGS="${CFLAGS:-${RPM_OPT_FLAGS}}" LDFLAGS="${LDFLAGS:-${RPM_LD_FLAGS}}"\\\
-  %{__pyvenv} %{py_setup} %{?py_setup_args} bdist_wheel %{?*}
+  %{__pyvenv3} %{py_setup} %{?py_setup_args} bdist_wheel %{?*}
   sleep 1
 }
 
-%pyvenv_install() %{expand:\\\
+%pyvenv_install_3() %{expand:\\\
   %{__pyvenvpip3} install -I dist/*.whl  $PYVENV_PIP_ARGS
-  find  %{__pyvenv_root} -type f -print0 | xargs -0 sed -i 's~%{buildroot}~~'
+  find %{buildroot}/%{__pyvenv_root} -type f -print0 | xargs -0 sed -i 's~%{buildroot}~~'
+}
+
+%pyvenv_create_2() %{expand:\\\
+  mkdir -p %{buildroot}/%{__pyvenv_root}
+  CFLAGS="${CFLAGS:-${RPM_OPT_FLAGS}}" LDFLAGS="${LDFLAGS:-${RPM_LD_FLAGS}}"\\\
+  virtualenv -p %{__python2} %{buildroot}/%{__pyvenv_root} %{?*}
+  %{__pyvenvpip2} install wheel $PYVENV_WHEEL_ARGS
+  sleep 1
+}
+
+%pyvenv_build_2() %{expand:\\\
+  CFLAGS="${CFLAGS:-${RPM_OPT_FLAGS}}" LDFLAGS="${LDFLAGS:-${RPM_LD_FLAGS}}"\\\
+  %{__pyvenv2} %{py_setup} %{?py_setup_args} bdist_wheel %{?*}
+  sleep 1
+}
+
+%pyvenv_install_2() %{expand:\\\
+  %{__pyvenvpip2} install -I dist/*.whl  $PYVENV_PIP_ARGS
+  find %{buildroot}/%{__pyvenv_root} -type f -print0 | xargs -0 sed -i 's~%{buildroot}~~'
 }


### PR DESCRIPTION
%__pyvenv_root variable is documented as modifiable, but that wasn't
technically the case as non-/opt/venvs/%{name} directories ended up
breaking the macro.

Fix macro to support modifying %__pyvenv_root, and clarify documentation
around it's use.